### PR TITLE
Implement read-only mode for RoomPolygonEditor configuration

### DIFF
--- a/sobits_slam/launch/room_polygon_editor.launch.py
+++ b/sobits_slam/launch/room_polygon_editor.launch.py
@@ -5,7 +5,6 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
@@ -67,7 +66,7 @@ def generate_launch_description():
         parameters=[
             {
                 "config_path": LaunchConfiguration("config_path"),
-                "read_only": ParameterValue(LaunchConfiguration("read_only"), value_type=bool),
+                "read_only": LaunchConfiguration("read_only"),
             }
         ],
     )

--- a/sobits_slam/launch/room_polygon_editor.launch.py
+++ b/sobits_slam/launch/room_polygon_editor.launch.py
@@ -5,6 +5,7 @@ from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def generate_launch_description():
@@ -27,6 +28,11 @@ def generate_launch_description():
         "config_path",
         default_value=default_config,
         description="Full path to the room information YAML file.",
+    )
+    read_only_arg = DeclareLaunchArgument(
+        "read_only",
+        default_value="false",
+        description="If true, publish room polygon markers without opening the editor GUI or accepting point edits.",
     )
 
     map_server = Node(
@@ -58,7 +64,12 @@ def generate_launch_description():
         executable="room_polygon_setting",
         name="room_polygon_setting",
         output="screen",
-        parameters=[{"config_path": LaunchConfiguration("config_path")}],
+        parameters=[
+            {
+                "config_path": LaunchConfiguration("config_path"),
+                "read_only": ParameterValue(LaunchConfiguration("read_only"), value_type=bool),
+            }
+        ],
     )
 
     return LaunchDescription(
@@ -66,6 +77,7 @@ def generate_launch_description():
             map_arg,
             rviz_arg,
             config_arg,
+            read_only_arg,
             map_server,
             lifecycle_manager,
             rviz,

--- a/sobits_slam/sobits_slam/room_polygon_setting.py
+++ b/sobits_slam/sobits_slam/room_polygon_setting.py
@@ -84,7 +84,26 @@ class RoomPolygonSetting(Node):
         self.declare_parameter("config_path", "")
         self.declare_parameter("read_only", False)
         self.config_path = ""
-        self.read_only = bool(self.get_parameter("read_only").value)
+        read_only_param = self.get_parameter("read_only").value
+        if isinstance(read_only_param, bool):
+            self.read_only = read_only_param
+        elif isinstance(read_only_param, str):
+            normalized = read_only_param.strip().lower()
+            if normalized in {"true", "1", "yes", "on"}:
+                self.read_only = True
+            elif normalized in {"false", "0", "no", "off", ""}:
+                self.read_only = False
+            else:
+                self.get_logger().warning(
+                    f"Invalid 'read_only' value '{read_only_param}'. Falling back to False."
+                )
+                self.read_only = False
+        else:
+            self.get_logger().warning(
+                f"'read_only' parameter has unsupported type {type(read_only_param).__name__}. "
+                "Falling back to False."
+            )
+            self.read_only = False
 
         self.goal_pose_sub = None
         if not self.read_only:
@@ -149,8 +168,10 @@ class RoomPolygonSetting(Node):
 
         config_path = Path(self.config_path)
         if not config_path.exists():
-            self.room_polygons = {}
+            with self.lock:
+                self.room_polygons = {}
             self.set_status(f"New room file selected: {config_path}")
+            self.publish_room_markers()
             return
 
         with open(config_path, "r", encoding="utf-8") as file:

--- a/sobits_slam/sobits_slam/room_polygon_setting.py
+++ b/sobits_slam/sobits_slam/room_polygon_setting.py
@@ -133,7 +133,7 @@ class RoomPolygonSetting(Node):
             self.width = self.tk.winfo_screenwidth()
             self.height = self.tk.winfo_screenheight()
 
-        self.status_var = tk.StringVar(value="Select a room file to begin.") if self.tk else None
+        self.status_var = tk.StringVar(self.tk, value="Select a room file to begin.") if self.tk else None
         self.room_listbox = None
         self.point_listbox = None
 

--- a/sobits_slam/sobits_slam/room_polygon_setting.py
+++ b/sobits_slam/sobits_slam/room_polygon_setting.py
@@ -12,6 +12,7 @@ import rclpy
 import yaml
 from geometry_msgs.msg import Point
 from geometry_msgs.msg import PoseStamped
+from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from rclpy.qos import QoSDurabilityPolicy, QoSProfile, QoSReliabilityPolicy
 from visualization_msgs.msg import Marker, MarkerArray
@@ -81,14 +82,18 @@ class RoomPolygonSetting(Node):
         super().__init__("room_polygon_setting")
 
         self.declare_parameter("config_path", "")
+        self.declare_parameter("read_only", False)
         self.config_path = ""
+        self.read_only = bool(self.get_parameter("read_only").value)
 
-        self.goal_pose_sub = self.create_subscription(
-            PoseStamped,
-            "/goal_pose",
-            self.goal_pose_callback,
-            1,
-        )
+        self.goal_pose_sub = None
+        if not self.read_only:
+            self.goal_pose_sub = self.create_subscription(
+                PoseStamped,
+                "/goal_pose",
+                self.goal_pose_callback,
+                1,
+            )
         marker_qos = QoSProfile(
             depth=1,
             reliability=QoSReliabilityPolicy.RELIABLE,
@@ -100,12 +105,16 @@ class RoomPolygonSetting(Node):
         self.room_polygons = {}
         self.selected_room = None
 
-        self.tk = tk.Tk()
-        self.tk.title("[Room Polygon] Map Information Setting GUI")
-        self.width = self.tk.winfo_screenwidth()
-        self.height = self.tk.winfo_screenheight()
+        self.tk = None
+        self.width = 0
+        self.height = 0
+        if not self.read_only:
+            self.tk = tk.Tk()
+            self.tk.title("[Room Polygon] Map Information Setting GUI")
+            self.width = self.tk.winfo_screenwidth()
+            self.height = self.tk.winfo_screenheight()
 
-        self.status_var = tk.StringVar(value="Select a room file to begin.")
+        self.status_var = tk.StringVar(value="Select a room file to begin.") if self.tk else None
         self.room_listbox = None
         self.point_listbox = None
 
@@ -141,7 +150,7 @@ class RoomPolygonSetting(Node):
         config_path = Path(self.config_path)
         if not config_path.exists():
             self.room_polygons = {}
-            self.status_var.set(f"New room file selected: {config_path}")
+            self.set_status(f"New room file selected: {config_path}")
             return
 
         with open(config_path, "r", encoding="utf-8") as file:
@@ -166,8 +175,13 @@ class RoomPolygonSetting(Node):
         if self.selected_room not in self.room_polygons:
             self.selected_room = next(iter(self.room_polygons), None)
 
-        self.status_var.set(f"Loaded room polygons from {config_path}")
+        self.set_status(f"Loaded room polygons from {config_path}")
         self.publish_room_markers()
+
+    def set_status(self, message: str):
+        if self.status_var is not None:
+            self.status_var.set(message)
+        self.get_logger().info(message)
 
     def save_config(self):
         config_path = Path(self.config_path or _default_room_info_path())
@@ -521,6 +535,19 @@ def main(args=None):
 
     configured_path = str(node.get_parameter("config_path").value).strip()
     node.config_path = configured_path or str(_default_room_info_path())
+
+    if node.read_only:
+        node.load_config()
+        node.publish_room_markers()
+        try:
+            rclpy.spin(node)
+        except (KeyboardInterrupt, ExternalShutdownException):
+            pass
+        finally:
+            node.destroy_node()
+            if rclpy.ok():
+                rclpy.shutdown()
+        return
 
     try:
         node.select_config_file()


### PR DESCRIPTION
This pull request introduces a new "read-only" mode to the room polygon editor, allowing the system to publish room polygon markers without launching the GUI or accepting edits. The changes ensure that the node can operate in a headless, non-interactive mode, which is useful for automated or deployment scenarios. Additionally, the codebase is refactored to cleanly separate GUI and non-GUI logic and improve status reporting.

**Read-only mode support:**

* Added a `read_only` launch argument to `room_polygon_editor.launch.py`, and passed it as a parameter to the `room_polygon_setting` node. When enabled, the node publishes room polygon markers without opening the editor GUI or accepting point edits. [[1]](diffhunk://#diff-6117606090b0addfcbb1244389b6098b26d1dbf23baed0019e6a7552fb4e9309R8) [[2]](diffhunk://#diff-6117606090b0addfcbb1244389b6098b26d1dbf23baed0019e6a7552fb4e9309R32-R36) [[3]](diffhunk://#diff-6117606090b0addfcbb1244389b6098b26d1dbf23baed0019e6a7552fb4e9309L61-R80)
* In `room_polygon_setting.py`, added logic to declare and check the `read_only` parameter, skipping GUI (Tkinter) initialization and subscription to `/goal_pose` when in read-only mode. [[1]](diffhunk://#diff-0b6967caa66885822474c3fb464ca16c121d3babe236e9ef304cfbee9f258acfR85-R90) [[2]](diffhunk://#diff-0b6967caa66885822474c3fb464ca16c121d3babe236e9ef304cfbee9f258acfR108-R117)

**Node lifecycle and status handling:**

* In read-only mode, the node loads the config, publishes room markers, and spins without GUI interaction; shutdown is handled gracefully.
* Refactored status updates: introduced a `set_status` method to update the status both in the GUI (if present) and via logging, replacing direct `status_var.set` calls. [[1]](diffhunk://#diff-0b6967caa66885822474c3fb464ca16c121d3babe236e9ef304cfbee9f258acfL144-R153) [[2]](diffhunk://#diff-0b6967caa66885822474c3fb464ca16c121d3babe236e9ef304cfbee9f258acfL169-R185)

**Dependency and import updates:**

* Added import for `ExternalShutdownException` to handle shutdown gracefully in read-only mode.