### PR TITLE
Jazzy/fix/param

### DIFF
--- a/sobits_nav/launch/include/navigation.launch.py
+++ b/sobits_nav/launch/include/navigation.launch.py
@@ -324,14 +324,15 @@ def generate_launch_description():
                         name='velocity_smoother',
                         parameters=[configured_params],
                         remappings=remappings
-                        + [('cmd_vel', 'cmd_vel_nav'), ('/cmd_vel_smoothed', velocity_topic_name)],
+                        + [('cmd_vel', 'cmd_vel_nav'), ('cmd_vel_smoothed', velocity_topic_name)],
                     ),
                     ComposableNode(
                         package='nav2_collision_monitor',
                         plugin='nav2_collision_monitor::CollisionMonitor',
                         name='collision_monitor',
                         parameters=[configured_params],
-                        remappings=remappings,
+                        remappings=remappings
+                        + [('cmd_vel_smoothed', velocity_topic_name)],
                     ),
                     ComposableNode(
                         package='opennav_docking',

--- a/sobits_nav/launch/nav2.launch.py
+++ b/sobits_nav/launch/nav2.launch.py
@@ -141,7 +141,7 @@ def generate_launch_description():
     declare_params_file_cmd = DeclareLaunchArgument(
         'params_file',
         default_value=PathJoinSubstitution(
-            [FindPackageShare('sobits_nav'), 'param', LaunchConfiguration('robot_name'), 'navigation_config.yaml']
+            [FindPackageShare('sobits_nav'), 'param', robot_name_val, 'navigation_config.yaml']
         ),
         description='Full path to nav2 params YAML; override from rc_doinglaundry for competition runs',
     )

--- a/sobits_nav/launch/nav2.launch.py
+++ b/sobits_nav/launch/nav2.launch.py
@@ -29,7 +29,7 @@ from launch.actions import (
 from launch.conditions import IfCondition
 from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration, PathJoinSubstitution, PythonExpression
-from launch_ros.actions import Node
+from launch_ros.actions import Node, SetParameter
 from launch_ros.actions import PushROSNamespace
 from launch_ros.descriptions import ParameterFile
 from launch_ros.substitutions import FindPackageShare
@@ -252,13 +252,19 @@ def generate_launch_description():
     bringup_cmd_group = GroupAction(
         [
             PushROSNamespace(condition=IfCondition(use_namespace), namespace=namespace),
+            # Apply costmap layer overrides globally so they take effect regardless of
+            # use_composition. Without this, custom_costmap_layer and keepout_filter.enabled
+            # were silently ignored when use_composition:=False because the inline dict on
+            # nav2_container was the only place they were set.
+            SetParameter('voxel_layer.observation_sources', custom_costmap_layer),
+            SetParameter('obstacle_layer.observation_sources', custom_costmap_layer),
+            SetParameter('keepout_filter.enabled', use_keepout_map),
             Node(
                 condition=IfCondition(use_composition),
                 name='nav2_container',
                 package='rclcpp_components',
                 executable='component_container_isolated',
-                parameters=[configured_params, {'autostart': autostart, 'keepout_filter.enabled': use_keepout_map, 'voxel_layer.observation_sources': custom_costmap_layer, 'obstacle_layer.observation_sources': custom_costmap_layer,}],
-                # parameters=[configured_params, {'autostart': autostart, 'keepout_filter.enabled': use_keepout_map,}],
+                parameters=[configured_params, {'autostart': autostart}],
                 arguments=['--ros-args', '--log-level', log_level],
                 remappings=remappings,
                 output='screen',

--- a/sobits_nav/launch/nav2.launch.py
+++ b/sobits_nav/launch/nav2.launch.py
@@ -84,9 +84,7 @@ def generate_launch_description():
     location_yaml_file = LaunchConfiguration('location')  # SOBITS Customize
     use_rviz = LaunchConfiguration('use_rviz')  # SOBITS Customize
     use_sim_time = LaunchConfiguration('use_sim_time')
-    params_file = PathJoinSubstitution(
-        [FindPackageShare('sobits_nav'), 'param', robot_name, 'navigation_config.yaml']
-    )
+    params_file = LaunchConfiguration('params_file')
     slamtool_param_file = PathJoinSubstitution(
         [FindPackageShare('sobits_slam'), 'param', robot_name, 'slamtool_config.yaml']
     )
@@ -138,6 +136,14 @@ def generate_launch_description():
         'robot_name',
         default_value=robot_name_val,
         description='TODO: merge of namespace param.....'
+    )
+
+    declare_params_file_cmd = DeclareLaunchArgument(
+        'params_file',
+        default_value=PathJoinSubstitution(
+            [FindPackageShare('sobits_nav'), 'param', LaunchConfiguration('robot_name'), 'navigation_config.yaml']
+        ),
+        description='Full path to nav2 params YAML; override from rc_doinglaundry for competition runs',
     )
 
     declare_namespace_cmd = DeclareLaunchArgument(
@@ -341,6 +347,7 @@ def generate_launch_description():
 
     # Declare the launch options
     ld.add_action(declare_robot_name_cmd)  # SOBITS Customize
+    ld.add_action(declare_params_file_cmd)  # SOBITS Customize
     ld.add_action(declare_namespace_cmd)
     ld.add_action(declare_use_namespace_cmd)
     ld.add_action(declare_slam_cmd)

--- a/sobits_nav/rviz/sobits_nav.rviz
+++ b/sobits_nav/rviz/sobits_nav.rviz
@@ -10,8 +10,11 @@ Panels:
         - /Global Layer1
         - /Local Layer1/Local Path1
         - /Local Layer1/Local Path1/Topic1
-      Splitter Ratio: 0.5833333134651184
-    Tree Height: 461
+        - /SOBIT HOME1
+        - /SOBIT HOME1/SOBIT HOME1
+        - /SOBIT LIGHT1
+      Splitter Ratio: 0.4927007257938385
+    Tree Height: 1128
   - Class: rviz_common/Selection
     Name: Selection
   - Class: rviz_common/Tool Properties
@@ -159,7 +162,14 @@ Visualization Manager:
           Enabled: true
           Name: Location TF viewer
           Namespaces:
-            {}
+            kitchen#basket: true
+            kitchen#basket_label: true
+            kitchen#folding_table: true
+            kitchen#folding_table_label: true
+            kitchen#washing_machine: true
+            kitchen#washing_machine_label: true
+            laundry_room#washing_machine: true
+            laundry_room#washing_machine_label: true
           Topic:
             Depth: 5
             Durability Policy: Volatile
@@ -239,32 +249,6 @@ Visualization Manager:
     - Class: rviz_common/Group
       Displays:
         - Alpha: 1
-          Class: rviz_default_plugins/RobotModel
-          Collision Enabled: false
-          Description File: ""
-          Description Source: Topic
-          Description Topic:
-            Depth: 5
-            Durability Policy: Volatile
-            History Policy: Keep Last
-            Reliability Policy: Reliable
-            Value: /sobit_home/robot_description
-          Enabled: true
-          Links:
-            All Links Enabled: true
-            Expand Joint Details: false
-            Expand Link Details: false
-            Expand Tree: false
-            Link Tree Style: Links in Alphabetic Order
-          Mass Properties:
-            Inertia: false
-            Mass: false
-          Name: SOBIT HOME
-          TF Prefix: sobit_home
-          Update Interval: 0
-          Value: true
-          Visual Enabled: true
-        - Alpha: 1
           Autocompute Intensity Bounds: true
           Autocompute Value Bounds:
             Max Value: 0
@@ -298,6 +282,463 @@ Visualization Manager:
           Use Fixed Frame: true
           Use rainbow: true
           Value: true
+        - Alpha: 1
+          Class: rviz_default_plugins/RobotModel
+          Collision Enabled: false
+          Description File: ""
+          Description Source: Topic
+          Description Topic:
+            Depth: 5
+            Durability Policy: Volatile
+            History Policy: Keep Last
+            Reliability Policy: Reliable
+            Value: /sobit_home/robot_description
+          Enabled: true
+          Links:
+            All Links Enabled: true
+            Expand Joint Details: false
+            Expand Link Details: false
+            Expand Tree: false
+            Link Tree Style: Links in Alphabetic Order
+            arm_left_base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_left_elbow_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_left_elbow_sub_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            arm_left_lower_flex_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_left_shoulder_tilt_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_left_upper_flex_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_left_upper_flex_sub_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            arm_left_upper_roll_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_left_upper_roll_sub_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            arm_left_wrist_roll_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_left_wrist_tilt_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_right_base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_right_elbow_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_right_elbow_sub_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            arm_right_lower_flex_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_right_shoulder_tilt_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_right_upper_flex_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_right_upper_flex_sub_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            arm_right_upper_roll_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_right_upper_roll_sub_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            arm_right_wrist_roll_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            arm_right_wrist_tilt_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            base_footprint:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            body_lift_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            body_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_camera_base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_camera_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_camera_optical_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            hand_left_cmc_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_end_effector_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            hand_left_finger_c_ip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_finger_c_mcp_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_finger_l_dip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_finger_l_mcp_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_finger_l_pip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_finger_r_dip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_finger_r_mcp_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_left_finger_r_pip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_camera_base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_camera_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_camera_optical_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            hand_right_cmc_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_end_effector_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            hand_right_finger_c_ip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_finger_c_mcp_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_finger_l_dip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_finger_l_mcp_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_finger_l_pip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_finger_r_dip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_finger_r_mcp_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            hand_right_finger_r_pip_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            head_base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            head_camera_IMU_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            head_camera_base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            head_camera_color_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            head_camera_color_optical_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            head_camera_color_screw_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            head_camera_depth_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            head_camera_left_ir_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            head_camera_left_ir_optical_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            head_camera_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            head_camera_right_ir_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            head_camera_right_ir_optical_frame:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            head_pan_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            head_tilt_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            lidar_back_base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            lidar_back_laser:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            lidar_back_laser_mount:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            lidar_front_base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            lidar_front_laser:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            lidar_front_laser_mount:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            lidar_merged_laser:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+            mic_base_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            mic_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            plate_bottom_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            plate_cover_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            plate_middle_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            plate_top_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_drive_b_l_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_drive_b_r_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_drive_f_l_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_drive_f_r_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_steer_b_l_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_steer_b_r_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_steer_base_b_l_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_steer_base_b_r_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_steer_base_f_l_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_steer_base_f_r_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_steer_f_l_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+            wheel_steer_f_r_link:
+              Alpha: 1
+              Show Axes: false
+              Show Trail: false
+              Value: true
+          Mass Properties:
+            Inertia: false
+            Mass: false
+          Name: SOBIT HOME
+          TF Prefix: ""
+          Update Interval: 0
+          Value: true
+          Visual Enabled: true
       Enabled: true
       Name: SOBIT HOME
     - Class: rviz_common/Group
@@ -665,7 +1106,7 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Angle: -1.5700000524520874
+      Angle: -1.5150007009506226
       Class: rviz_default_plugins/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
@@ -675,21 +1116,21 @@ Visualization Manager:
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Scale: 101.333251953125
+      Scale: 47.230369567871094
       Target Frame: <Fixed Frame>
       Value: TopDownOrtho (rviz_default_plugins)
-      X: 2.133584499359131
-      Y: -0.44127827882766724
+      X: 2.596978187561035
+      Y: -2.6632134914398193
     Saved: ~
 Window Geometry:
   Displays:
     collapsed: false
-  Height: 704
+  Height: 1371
   Hide Left Dock: false
   Hide Right Dock: true
   Navigation 2:
     collapsed: false
-  QMainWindow State: 000000ff00000000fd00000004000000000000016a00000227fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afc0000003d00000227000001fc0100001cfa000000010100000002fb00000018004e0061007600690067006100740069006f006e002000320100000000ffffffff0000012b00fffffffb000000100044006900730070006c00610079007301000000000000016a0000015600fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000001e005200650061006c00730065006e0073006500430061006d00650072006100000002c6000000c10000000000000000000000010000010f00000227fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000227000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000051000000039fc0100000002fb0000000800540069006d00650100000000000005100000022700fffffffb0000000800540069006d00650100000000000004500000000000000000000003a00000022700000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  QMainWindow State: 000000ff00000000fd000000040000000000000226000004c2fc0200000009fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afc0000003d000004c2000001fc0100001cfa000000010100000002fb00000018004e0061007600690067006100740069006f006e002000320100000000ffffffff0000012b00fffffffb000000100044006900730070006c00610079007301000000000000016a0000015600fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb0000001e005200650061006c00730065006e0073006500430061006d00650072006100000002c6000000c10000000000000000000000010000010f00000227fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d00000227000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000009be00000039fc0100000002fb0000000800540069006d00650100000000000009be0000022700fffffffb0000000800540069006d0065010000000000000450000000000000000000000792000004c200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -698,6 +1139,6 @@ Window Geometry:
     collapsed: false
   Views:
     collapsed: true
-  Width: 1296
-  X: 70
-  Y: 27
+  Width: 2494
+  X: 66
+  Y: 32


### PR DESCRIPTION
This pull request introduces several improvements and fixes to the launch files for navigation in the `sobits_nav` package. The main changes focus on making parameter file selection more flexible, ensuring costmap parameters are set globally, and correcting remapping issues to improve compatibility and maintainability.

**Parameter management and flexibility:**

* Added a new launch argument `params_file` to allow overriding the navigation parameter YAML file, making it easier to use custom configurations for different robots or competition runs. The default value is set based on the robot name, and all parameter file references now use this argument. (`sobits_nav/launch/nav2.launch.py`) [[1]](diffhunk://#diff-3f744106a244fe76687dcbeec66ac94ae8c60ca46f24a572395f298bc915de3cL87-R87) [[2]](diffhunk://#diff-3f744106a244fe76687dcbeec66ac94ae8c60ca46f24a572395f298bc915de3cR141-R148) [[3]](diffhunk://#diff-3f744106a244fe76687dcbeec66ac94ae8c60ca46f24a572395f298bc915de3cR356)

**Costmap parameter handling:**

* Introduced global `SetParameter` actions for `voxel_layer.observation_sources`, `obstacle_layer.observation_sources`, and `keepout_filter.enabled` so that these settings are applied regardless of whether node composition is used. This prevents silent misconfigurations when `use_composition` is `False`. (`sobits_nav/launch/nav2.launch.py`)

**Remapping corrections:**

* Fixed remapping keys in `navigation.launch.py` to use the correct topic names without leading slashes, ensuring topics are properly connected for `velocity_smoother` and `collision_monitor` nodes. (`sobits_nav/launch/include/navigation.launch.py`)

**Imports and code cleanup:**

* Added the `SetParameter` import to support the new parameter-setting actions. (`sobits_nav/launch/nav2.launch.py`)

These changes improve the flexibility, reliability, and maintainability of the navigation launch process.